### PR TITLE
Revert "select2Options.width = "element" as default"

### DIFF
--- a/themes/bootstrap3.js
+++ b/themes/bootstrap3.js
@@ -20,11 +20,7 @@ Template["afSelect2_bootstrap3"].helpers({
 
 Template["afSelect2_bootstrap3"].rendered = function () {
   // instanciate select2
-  var select2Options = this.data.atts.select2Options || {};
-  if (!select2Options.width) {
-    select2Options.width = "element";
-  }
-  this.$('select').select2(select2Options);
+  this.$('select').select2(this.data.atts.select2Options || {});
 };
 
 Template["afSelect2_bootstrap3"].destroyed = function () {


### PR DESCRIPTION
Sorry, border bugfix works only for 150%, but added bug of resize

I found this bug in http://autoform-placecomplete.meteor.com/

I dont know, how to fix it.
