### PR TITLE
Fix: Update form not displaying values for 'multiple=true' field

### DIFF
--- a/autoform-select2.js
+++ b/autoform-select2.js
@@ -70,7 +70,9 @@ AutoForm.addInputType("select2", {
         // #each uses to track unique list items when adding and removing them
         // See https://github.com/meteor/meteor/issues/2174
         _id: opt.value,
-        selected: (opt.value === context.value),
+        selected: (_.isArray(context.value) ?
+                   _.contains(context.value, opt.value) :
+                   opt.value === context.value),
         atts: itemAtts
       });
     });


### PR DESCRIPTION
Fix for https://github.com/aldeed/meteor-autoform-select2/issues/3 Update form not displaying values for 'multiple=true' field
