### PR TITLE
Prepend an empty option for single select fields with non-empty placeholder

### DIFF
--- a/autoform-select2.js
+++ b/autoform-select2.js
@@ -51,6 +51,15 @@ AutoForm.addInputType("select2", {
     // build items list
     context.items = [];
 
+    // When single-select and placeholder is passed,
+    // the first option should be an empty option.
+    var multiple = itemAtts.multiple;
+    var select2Options = itemAtts.select2Options || {};
+
+    if (!multiple && select2Options.placeholder) {
+      context.items.push('');
+    }
+
     // Check if option is selected
     var isSelected = function(conVal, optVal) {
       return _.isArray(conVal) ? _.contains(conVal, optVal) : optVal === conVal;


### PR DESCRIPTION
Related issue https://github.com/aldeed/meteor-autoform-select2/issues/40
