### PR TITLE
get rid from the error & close issue #44

### DIFF
--- a/autoform-select2.js
+++ b/autoform-select2.js
@@ -172,7 +172,7 @@ Template.afSelect2.rendered = function () {
 
 Template.afSelect2.destroyed = function () {
   try {
-    if (this.view && this.view._domrange) {
+    if (this.view && this.view._domrange && this.$('select').data('select2')) {
       this.$('select').select2('destroy');
     }
   } catch (error) {}


### PR DESCRIPTION
in line 176 we may destroy non existing select2 - this is causing the error when we have no select2 previously attached to the field

in line 175 i've added check for that
