### PR TITLE
allow use of autoform 4 or 5

### DIFF
--- a/autoform-select2.js
+++ b/autoform-select2.js
@@ -65,8 +65,6 @@ AutoForm.addInputType('select2', {
       return _.isArray(conVal) ? _.contains(conVal, optVal) : optVal === conVal;
     };
 
-    console.log(context);
-
     // Add all defined options
     _.each(context.selectOptions, function(opt) {
       if (opt.optgroup) {

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'aldeed:autoform-select2',
   summary: 'Custom select2 input type for AutoForm',
-  version: '3.0.0',
+  version: '3.0.1',
   git: 'https://github.com/aldeed/meteor-autoform-select2.git'
 });
 
@@ -10,7 +10,7 @@ Package.onUse(function(api) {
   api.use('templating@1.0.0');
   api.use('blaze@2.0.0');
   api.use('aldeed:template-extension@4.0.0');
-  api.use('aldeed:autoform@6.0.0');
+  api.use('aldeed:autoform@4.0.0 || 5.0.0 || 6.0.0');
   api.addFiles([
     'autoform-select2.html',
     'autoform-select2.js'


### PR DESCRIPTION
With the `api.use('aldeed:autoform@6.0.0')` meteor will throw a "Potentially incompatible change" error.